### PR TITLE
fix(build): correct export endpoint for ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "author": "Jacob Gillespie <jacobwgillespie@gmail.com>",
   "license": "MIT",
   "packageManager": "pnpm@9.11.0",
-  "main": "./dist/index.js",
+  "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "module": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "exports": {
     "types": "./dist/index.d.ts",
     "import": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "module": "./dist/index.mjs",
   "exports": {
     "types": "./dist/index.d.ts",
-    "import": "./dist/index.js",
+    "import": "./dist/index.mjs",
     "require": "./dist/index.cjs"
   },
   "files": [


### PR DESCRIPTION
After [migration from `tsdown` to `tsup`](https://github.com/depot/node-spiffe/commit/76de771cd5fb5f3fec2d7f5c0541594357dd71c2), `index.js` is no longer being built in latest `spiffe` version
<img width="827" height="450" alt="image" src="https://github.com/user-attachments/assets/e12405d7-0d24-4bf3-a737-9b54ebab6fa8" />

And thus to fix below error, the export endpoint for ESM build by default must be changed.

<img width="827" height="305" alt="image" src="https://github.com/user-attachments/assets/92823022-65b5-4fc6-8c5f-af08cd5142e6" />


I've tested with the change and this is the expected error
<img width="827" height="305" alt="image" src="https://github.com/user-attachments/assets/54b86961-4fe9-4be2-9cc9-d6fb08c0ee55" />
